### PR TITLE
change old UserPluginBase imports to NuitkaPluginBase

### DIFF
--- a/hinted-compilation/torch-plugin.py
+++ b/hinted-compilation/torch-plugin.py
@@ -25,7 +25,7 @@ import pkgutil
 import shutil
 from logging import info
 from nuitka import Options
-from nuitka.plugins.PluginBase import UserPluginBase
+from nuitka.plugins.PluginBase import NuitkaPluginBase
 from nuitka.plugins.Plugins import active_plugin_list
 from nuitka.utils.Utils import isWin32Windows
 from nuitka.ModuleRegistry import (
@@ -76,7 +76,7 @@ def get_torch_core_binaries():
     return binaries
 
 
-class Usr_Plugin(UserPluginBase):
+class Usr_Plugin(NuitkaPluginBase):
 
     plugin_name = __file__
 

--- a/make-distribution.py
+++ b/make-distribution.py
@@ -21,11 +21,11 @@ import os
 import subprocess
 from logging import info
 from nuitka import Options
-from nuitka.plugins.PluginBase import UserPluginBase
+from nuitka.plugins.PluginBase import NuitkaPluginBase
 from nuitka.utils.Timing import StopWatch
 
 
-class MyExit(UserPluginBase):
+class MyExit(NuitkaPluginBase):
     """ User plugin supporting post-processing in standalone mode.
 
     Notes:


### PR DESCRIPTION
as of 0.6.4 (specifically https://github.com/Nuitka/Nuitka/commit/6dbffa42e0ee46f0179600395b407a2eecb383ce), the UserPluginBase class has been removed. Barring documentation, Plugins should supposedly use the NuitkaPluginBase class instead.

This PR changes all usages of UserPluginBase to NuitkaPluginBase.