### PR TITLE
Fix double backslash problems

### DIFF
--- a/hinted-compilation/get-hints.py
+++ b/hinted-compilation/get-hints.py
@@ -366,6 +366,7 @@ ifpath = os.path.dirname(os.path.abspath(ifname))
 ifbasename = os.path.basename(os.path.abspath(ifname))
 
 scriptname, extname = os.path.splitext(ifname)
+scriptname = scriptname.replace('\\', '/')
 jname = "%s-%i%i-%s-%i.json" % (
     scriptname,
     sys.version_info.major,


### PR DESCRIPTION
Using get-hints.py, the invoke_text = """...""".replace(&scriptname, scriptname) will convert double backslashes in scriptname to single ones.
Hence, if a path is `C:\\test` it will become `C:\test` where `\t` is a tabulation.
This fixes that behavior by converting backslashes to slashes.