### PR TITLE
delta changed to getDelta for 0.6.9.2

### DIFF
--- a/hinted-compilation/hinted-mods.py
+++ b/hinted-compilation/hinted-mods.py
@@ -431,7 +431,7 @@ class HintedModsPlugin(NuitkaPluginBase):
     def onStandaloneDistributionFinished(self, dist_dir):
         """ Only used to output the compilation time."""
         self.timer.end()
-        t = int(round(self.timer.delta()))
+        t = int(round(self.timer.getDelta()))
         if t > 240:
             unit = "minutes"
             if t >= 600:


### PR DESCRIPTION
nuitka.utils.Timing import StopWatch is no longer delta(), but getDelta() - this causing an error when running hinted-mods.py.